### PR TITLE
Introduce ubicloud/cache package

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ npm install @actions/io
 
 Provides functions for downloading and caching tools.  e.g. setup-* actions. Read more [here](packages/tool-cache)
 
-See @actions/cache for caching workflow dependencies.
+See @ubicloud/cache for caching workflow dependencies.
 
 ```bash
 $ npm install @actions/tool-cache
@@ -93,12 +93,12 @@ $ npm install @actions/artifact
 ```
 <br/>
 
-:dart: [@actions/cache](packages/cache)
+:dart: [@ubicloud/cache](packages/cache)
 
 Provides functions to cache dependencies and build outputs to improve workflow execution time. Read more [here](packages/cache)
 
 ```bash
-$ npm install @actions/cache
+$ npm install @ubicloud/cache
 ```
 <br/>
 

--- a/docs/adrs/0381-glob-module.md
+++ b/docs/adrs/0381-glob-module.md
@@ -146,7 +146,7 @@ Example:
 jobs:
   build:
     steps:
-      - uses: actions/cache@v1
+      - uses: ubicloud/cache@v1
         with:
           hash: ${{ hashFiles('--follow-symbolic-links', '**/package-lock.json') }}
 ```

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -1,4 +1,4 @@
-# `@actions/cache`
+# `@ubicloud/cache`
 
 > Functions necessary for caching dependencies and build outputs to improve workflow execution time.
 
@@ -8,14 +8,14 @@ Note that GitHub will remove any cache entries that have not been accessed in ov
 
 ## Usage
 
-This package is used by the v2+ versions of our first party cache action. You can find an example implementation in the cache repo [here](https://github.com/actions/cache).
+This package is used by the v2+ versions of our first party cache action. You can find an example implementation in the cache repo [here](https://github.com/ubicloud/cache).
 
 #### Save Cache
 
 Saves a cache containing the files in `paths` using the `key` provided. The files would be compressed using zstandard compression algorithm if zstd is installed, otherwise gzip is used. Function returns the cache id if the cache was saved succesfully and throws an error if cache upload fails.
 
 ```js
-const cache = require('@actions/cache');
+const cache = require('@ubicloud/cache');
 const paths = [
     'node_modules',
     'packages/*/node_modules/'
@@ -29,7 +29,7 @@ const cacheId = await cache.saveCache(paths, key)
 Restores a cache based on `key` and `restoreKeys` to the `paths` provided. Function returns the cache key for cache hit and returns undefined if cache not found.
 
 ```js
-const cache = require('@actions/cache');
+const cache = require('@ubicloud/cache');
 const paths = [
     'node_modules',
     'packages/*/node_modules/'

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@actions/cache",
-  "version": "3.2.4",
+  "name": "@ubicloud/cache",
+  "version": "3.2.403",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@actions/cache",
-      "version": "3.2.4",
+      "name": "@ubicloud/cache",
+      "version": "3.2.403",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,14 +1,15 @@
 {
-  "name": "@actions/cache",
-  "version": "3.2.4",
+  "name": "@ubicloud/cache",
+  "version": "3.2.403",
   "preview": true,
-  "description": "Actions cache lib",
+  "description": "Ubicloud GitHub Actions cache lib",
   "keywords": [
+    "ubicloud",
     "github",
     "actions",
     "cache"
   ],
-  "homepage": "https://github.com/actions/toolkit/tree/main/packages/cache",
+  "homepage": "https://github.com/ubicloud/toolkit/tree/main/packages/cache",
   "license": "MIT",
   "main": "lib/cache.js",
   "types": "lib/cache.d.ts",
@@ -25,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/toolkit.git",
+    "url": "git+https://github.com/ubicloud/toolkit.git",
     "directory": "packages/cache"
   },
   "scripts": {
@@ -34,7 +35,7 @@
     "tsc": "tsc"
   },
   "bugs": {
-    "url": "https://github.com/actions/toolkit/issues"
+    "url": "https://github.com/ubicloud/toolkit/issues"
   },
   "dependencies": {
     "@actions/core": "^1.10.0",

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -50,7 +50,7 @@ function checkKey(key: string): void {
  */
 
 export function isFeatureAvailable(): boolean {
-  return !!process.env['ACTIONS_CACHE_URL']
+  return !!process.env['UBICLOUD_CACHE_URL']
 }
 
 /**

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -40,12 +40,12 @@ import {
 const versionSalt = '1.0'
 
 function getCacheApiUrl(resource: string): string {
-  const baseUrl: string = process.env['ACTIONS_CACHE_URL'] || ''
+  const baseUrl: string = process.env['UBICLOUD_CACHE_URL'] || ''
   if (!baseUrl) {
     throw new Error('Cache Service Url not found, unable to restore cache.')
   }
 
-  const url = `${baseUrl}_apis/artifactcache/${resource}`
+  const url = `${baseUrl}${resource}`
   core.debug(`Resource Url: ${url}`)
   return url
 }
@@ -65,11 +65,11 @@ function getRequestOptions(): RequestOptions {
 }
 
 function createHttpClient(): HttpClient {
-  const token = process.env['ACTIONS_RUNTIME_TOKEN'] || ''
+  const token = process.env['UBICLOUD_RUNTIME_TOKEN'] || ''
   const bearerCredentialHandler = new BearerCredentialHandler(token)
 
   return new HttpClient(
-    'actions/cache',
+    'ubicloud/cache',
     [bearerCredentialHandler],
     getRequestOptions()
   )

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -196,7 +196,11 @@ export async function downloadCache(
       await downloadCacheHttpClient(archiveLocation, archivePath)
     }
   } else {
-    await downloadCacheHttpClient(archiveLocation, archivePath)
+    await downloadCacheHttpClientConcurrent(
+      archiveLocation,
+      archivePath,
+      downloadOptions
+    )
   }
 }
 

--- a/packages/cache/src/internal/contracts.d.ts
+++ b/packages/cache/src/internal/contracts.d.ts
@@ -20,7 +20,9 @@ export interface ArtifactCacheList {
 }
 
 export interface CommitCacheRequest {
-  size: number
+  size: number,
+  uploadId: string,
+  etags: string[]
 }
 
 export interface ReserveCacheRequest {
@@ -30,7 +32,9 @@ export interface ReserveCacheRequest {
 }
 
 export interface ReserveCacheResponse {
-  cacheId: number
+  uploadId: string
+  presignedUrls: string[]
+  chunkSize: number
 }
 
 export interface InternalCacheOptions {

--- a/packages/cache/src/internal/downloadUtils.ts
+++ b/packages/cache/src/internal/downloadUtils.ts
@@ -172,7 +172,7 @@ export async function downloadCacheHttpClient(
   archivePath: string
 ): Promise<void> {
   const writeStream = fs.createWriteStream(archivePath)
-  const httpClient = new HttpClient('actions/cache')
+  const httpClient = new HttpClient('ubicloud/cache')
   const downloadResponse = await retryHttpClientResponse(
     'downloadCache',
     async () => httpClient.get(archiveLocation)
@@ -215,7 +215,7 @@ export async function downloadCacheHttpClientConcurrent(
   options: DownloadOptions
 ): Promise<void> {
   const archiveDescriptor = await fs.promises.open(archivePath, 'w')
-  const httpClient = new HttpClient('actions/cache', undefined, {
+  const httpClient = new HttpClient('ubicloud/cache', undefined, {
     socketTimeout: options.timeoutInMs,
     keepAlive: true
   })

--- a/packages/cache/src/internal/downloadUtils.ts
+++ b/packages/cache/src/internal/downloadUtils.ts
@@ -222,17 +222,17 @@ export async function downloadCacheHttpClientConcurrent(
   try {
     const res = await retryHttpClientResponse(
       'downloadCacheMetadata',
-      async () => await httpClient.request('HEAD', archiveLocation, null, {})
+      async () => await httpClient.get(archiveLocation, { Range: 'bytes=0-1' })
     )
 
-    const lengthHeader = res.message.headers['content-length']
-    if (lengthHeader === undefined || lengthHeader === null) {
-      throw new Error('Content-Length not found on blob response')
+    const contentRangeHeader = res.message.headers['content-range']
+    if (contentRangeHeader === undefined || contentRangeHeader === null) {
+      throw new Error('Content-Range not found on blob response')
     }
 
-    const length = parseInt(lengthHeader)
+    const length = parseInt(RegExp(/bytes \d+-\d+\/(\d+)/).exec(contentRangeHeader)?.[1] ?? '')
     if (Number.isNaN(length)) {
-      throw new Error(`Could not interpret Content-Length: ${length}`)
+      throw new Error(`Could not interpret Content-Range: ${length}`)
     }
 
     const downloads: {

--- a/packages/cache/src/options.ts
+++ b/packages/cache/src/options.ts
@@ -106,7 +106,7 @@ export function getDownloadOptions(copy?: DownloadOptions): DownloadOptions {
   const result: DownloadOptions = {
     useAzureSdk: false,
     concurrentBlobDownloads: true,
-    downloadConcurrency: 8,
+    downloadConcurrency: 10,
     timeoutInMs: 30000,
     segmentTimeoutInMs: 600000,
     lookupOnly: false


### PR DESCRIPTION
### Introduce ubicloud/cache package

The `actions/toolkit` repository provides a set of packages to make creating actions easier. We've forked this repository and refactored the `actions/cache` package into the `ubicloud/cache` package. This updated version can interact with Ubicloud's cache service. We aimed to retain as much of the original code as possible, but differences in the architecture of Azure Blob Storage and S3 compatible storage necessitated some changes.

This commit only modifies branding literals and the package name. Subsequent commits will implement changes to the code.

To stay in sync with GitHub's release cycle for the cache package, I've decided to keep our versioning as similar as possible. The only difference is that I've multiplied the patch version by `100`. So, if the original version is `3.2.4`, the corresponding version in the
`ubicloud/cache` package will be `3.2.401`. This approach simplifies version tracking and allows us to release multiple build versions for the same version of the original package.

I've also renamed `ACTIONS_CACHE_URL` to `UBICLOUD_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` to `UBICLOUD_RUNTIME_TOKEN`. We pass these variables to our runners during environment setup.


### Make saveCache Ubicloud compatible

`saveCache` consists of three main components: reserveCache, uploadFile, and commitCache. We use presigned URLs to enable the cache client to interact with blob storage without passing the blob storage credentials. The design of Azure blob storage and S3 compatible API cache differs in terms of concurrent file uploading. As Ubicloud uses an S3 compatible API, we need to make saveCache compatible with Ubicloud.

To enable concurrent file uploading, we first send a `CreateMultipartUpload` request to the blob storage. This request returns an `UploadId`, which we then use to upload the file in parts. Each uploaded part generates an `ETag`, which is essential for completing the upload. After uploading all parts, we send a `CompleteMultipartUpload` request, which includes all the `ETags` of the parts and the `UploadId`. This finalizes the upload, making the file available in the blob storage.

When the cache client sends a `reserveCache` request to the Ubicloud cache service, it triggers a `CreateMultipartUpload` request to the blob storage. This returns the `UploadId` and a presigned URL for each part to the cache client. The cache client then uses these presigned URLs to upload the file parts to blob storage and collects the `ETags` from each response. After all parts are uploaded, the cache client sends a `commitCache` request to the Ubicloud cache service, including the `ETags` and `UploadId`. The cache service then sends a `CompleteMultipartUpload` request to the blob storage to finalize the upload.


### Make downloadCacheHttpClientConcurrent Ubicloud compatible

We also use presigned URLs to restore caches from blob storage. The design of Azure blob storage and the S3 compatible API are more similar in terms of file downloading than uploading. Since Ubicloud uses an S3 compatible API, we need to ensure `restoreCache` is compatible with Ubicloud.

When the `restoreCache` method of the cache client called, it first sends a `getCacheEntry` request to the Ubicloud cache service. The response includes `archiveLocation`, a presigned URL used to download the cache. If this location is a URL from Azure Blob Storage, the download occurs concurrently. Otherwise, it downloads as a single thread.

The current implementation of `downloadCacheHttpClientConcurrent` is not compatible with the S3 compatible API. The main difference lies in how we obtain the file size. In Azure Blob Storage, we can get the file size by sending a HEAD request to the URL. However, with the S3 compatible API, we need to send a GET request to the URL with a `Range: bytes=0-1` header to get the file size. This PR ensures `downloadCacheHttpClientConcurrent` is compatible with the S3 compatible API.
