### PR TITLE
Send workflow run id to backend

### DIFF
--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -113,7 +113,7 @@ export async function getCacheEntry(
   )
   const resource = `cache?keys=${encodeURIComponent(
     keys.join(',')
-  )}&version=${version}`
+  )}&version=${version}&runId=${process.env['GITHUB_RUN_ID']}`
 
   const response = await retryTypedResponse('getCacheEntry', async () =>
     httpClient.getJson<ArtifactCacheEntry>(getCacheApiUrl(resource))
@@ -220,7 +220,8 @@ export async function reserveCache(
   const reserveCacheRequest: ReserveCacheRequest = {
     key,
     version,
-    cacheSize: options?.cacheSize
+    cacheSize: options?.cacheSize,
+    runId: process.env['GITHUB_RUN_ID']
   }
   const response = await retryTypedResponse('reserveCache', async () =>
     httpClient.postJson<ReserveCacheResponse>(

--- a/packages/cache/src/internal/contracts.d.ts
+++ b/packages/cache/src/internal/contracts.d.ts
@@ -29,6 +29,7 @@ export interface ReserveCacheRequest {
   key: string
   version?: string
   cacheSize?: number
+  runId?: string
 }
 
 export interface ReserveCacheResponse {


### PR DESCRIPTION
In happy path, we get the job scope from the webhook payload. However, there can be delays at webhook deliveries. In such cases, we send the run ID to the backend to retrieve the job scope from the GitHub API.